### PR TITLE
Improve OAuth error handling and user feedback

### DIFF
--- a/src/components/web/LoginPage.tsx
+++ b/src/components/web/LoginPage.tsx
@@ -13,7 +13,11 @@ export function LoginPage({ onBack }: LoginPageProps) {
   const { theme, toggleTheme } = useThemeStore()
   const isDark = theme === 'dark'
   const [loading, setLoading] = useState<'github' | 'google' | null>(null)
-  const [error, setError] = useState<string | null>(null)
+  const [error, setError] = useState<string | null>(() => {
+    const e = sessionStorage.getItem('auth_error')
+    if (e) sessionStorage.removeItem('auth_error')
+    return e
+  })
 
   const handleGitHub = async () => {
     setLoading('github')
@@ -120,7 +124,7 @@ export function LoginPage({ onBack }: LoginPageProps) {
             color: 'var(--color-text-muted)',
             textAlign: 'center',
           }}>
-            Connectez-vous dans la fenêtre qui s'est ouverte…
+            Redirection en cours…
           </p>
         )}
 

--- a/src/components/web/WebApp.tsx
+++ b/src/components/web/WebApp.tsx
@@ -66,6 +66,16 @@ export function WebApp() {
   // Supabase SDK automatically detects and exchanges the token/code in the URL.
   // Once done, session is set via onAuthStateChange → re-render handles routing.
   if (page === 'callback') {
+    // Detect OAuth error redirected back by Supabase (e.g. provider not enabled)
+    const params = new URLSearchParams(window.location.search)
+    const oauthError = params.get('error_description') || params.get('error')
+    if (oauthError) {
+      sessionStorage.setItem('auth_error', decodeURIComponent(oauthError))
+      window.history.replaceState({}, '', '/login')
+      setPage('login')
+      return <Splash />
+    }
+
     if (session) {
       // Restore pre-auth path (e.g. '/admin') saved before the OAuth redirect
       const from = sessionStorage.getItem('auth_redirect_from') || '/'

--- a/src/store/authStore.ts
+++ b/src/store/authStore.ts
@@ -47,10 +47,11 @@ export const useAuthStore = create<AuthStore>()(
         if (!isElectron) {
           // Persist current path so we can restore it after OAuth redirect
           sessionStorage.setItem('auth_redirect_from', window.location.pathname)
-          await supabase.auth.signInWithOAuth({
+          const { error } = await supabase.auth.signInWithOAuth({
             provider: 'github',
             options: { redirectTo: `${window.location.origin}/auth/callback` },
           })
+          if (error) throw error
           return
         }
         const { data, error } = await supabase.auth.signInWithOAuth({
@@ -66,10 +67,11 @@ export const useAuthStore = create<AuthStore>()(
         if (!isElectron) {
           // Persist current path so we can restore it after OAuth redirect
           sessionStorage.setItem('auth_redirect_from', window.location.pathname)
-          await supabase.auth.signInWithOAuth({
+          const { error } = await supabase.auth.signInWithOAuth({
             provider: 'google',
             options: { redirectTo: `${window.location.origin}/auth/callback` },
           })
+          if (error) throw error
           return
         }
         const { data, error } = await supabase.auth.signInWithOAuth({


### PR DESCRIPTION
## Summary
Enhanced OAuth authentication error handling to gracefully manage provider errors and improve user experience during the authentication flow.

## Key Changes
- **WebApp.tsx**: Added detection and handling of OAuth errors returned by Supabase in the callback URL. When an OAuth error occurs (e.g., provider not enabled), the error is stored in sessionStorage, the user is redirected to the login page, and a splash screen is shown.
- **LoginPage.tsx**: Modified error state initialization to retrieve any stored OAuth errors from sessionStorage and display them to the user. Updated the loading message from French to a more generic "Redirection en cours…" (Redirection in progress).
- **authStore.ts**: Added explicit error checking for both GitHub and Google OAuth sign-in calls. Errors from `signInWithOAuth` are now captured and thrown, ensuring proper error propagation instead of silently failing.

## Implementation Details
- OAuth errors are temporarily stored in sessionStorage during the callback redirect to preserve them across page navigation
- The error is automatically cleared from sessionStorage after being retrieved to prevent stale error messages
- URL history is cleaned up using `replaceState` to remove error parameters from the browser history
- Error handling is now consistent across both OAuth providers (GitHub and Google)

https://claude.ai/code/session_01Gz9ziigH45U8xrUsK6uG8t